### PR TITLE
Integrate release action for firmware deployment

### DIFF
--- a/.github/workflows/build_redmi_ax6000.yml
+++ b/.github/workflows/build_redmi_ax6000.yml
@@ -161,7 +161,20 @@ jobs:
           files: |
             ./artifact/${{ steps.currentdate.outputs.date }}.bin
             ./artifact/**/*.ipk
-
+      - uses: ncipollo/release-action@v1
+        with:
+          tag: "${{ steps.currentdate.outputs.date }}"
+          name: "${{ steps.currentdate.outputs.date }}"
+          makeLatest: true
+          generateReleaseNotes: true
+          artifacts: |
+            "./artifact/*.bin"
+            "./artifact/**/*.ipk"
+          body: |
+            ## Release Notes 
+            - This release includes the firmware for RedMi AX6000 boards.
+            - Please find the binary files in the assets section below.
+            
       - name: executing remote ssh commands using ssh key
         uses: appleboy/ssh-action@master
         with:


### PR DESCRIPTION
Add release action to GitHub workflow for RedMi AX6000 firmware.